### PR TITLE
Added unit testing capabilities

### DIFF
--- a/proxy_cache_aws.code-workspace
+++ b/proxy_cache_aws.code-workspace
@@ -5,12 +5,17 @@
 		}
 	],
 	"settings": {
+		"rust-analyzer.linkedProjects": [
+			".\\Cargo.toml",
+			".\\Cargo.toml"
+		]
 	},
 	"extensions": {
 		"recommendations": [
 			"rust-lang.rust-analyzer",
 			"vadimcn.vscode-lldb",
-			"swellaby.vscode-rust-test-adapter"
+			"swellaby.vscode-rust-test-adapter",
+			"hbenl.vscode-test-explorer"
 		]
 	},
 	"launch": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,7 @@ async fn say_secret(State(config) : State<Config>) -> String {
 mod tests {
     use super::*;
     use std::env;
-    /// This is a simple test case that demonstrates Rust unit tests.
-    /// It verifies that the serialized point deserializes as expected. 
+
     #[test]
     fn create_valid_addr() {
         env::set_var("APP_HOST", "127.0.0.1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,6 @@ mod tests {
     fn create_valid_addr() {
         env::set_var("APP_HOST", "127.0.0.1");
         env::set_var("APP_PORT", "5000");
-
         assert_eq!(create_addr().to_string(), "127.0.0.1:5000".to_string());
     }
     #[test]

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use std::time::Instant;
 
-pub async fn tracing_middleware<B>(request: Request<B>, next: Next<B>) -> Response {
+pub async fn tracing_fn<B>(request: Request<B>, next: Next<B>) -> Response {
     //Extract necessary information from the request
     let method = request.method().to_string();
     let url = request.uri().to_string();


### PR DESCRIPTION
To add unit tests only need to create a mod in file to test

![image](https://github.com/org-LOG795/proxy_cache_aws/assets/36003360/60266980-a6ce-4d86-b25d-b8ee688f434a)

Added vscode extension recommendation for a unit test UI

![image](https://github.com/org-LOG795/proxy_cache_aws/assets/36003360/401e44da-499e-4cb7-a7de-0a8e47c90942)

Unit tests can also be ran with the command "cargo test"

![image](https://github.com/org-LOG795/proxy_cache_aws/assets/36003360/76dc52a4-a7f3-4c5d-b9f5-c1a8d603de44)
